### PR TITLE
test: cypress configuration

### DIFF
--- a/vue-project/cypress.config.js
+++ b/vue-project/cypress.config.js
@@ -3,6 +3,6 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   e2e: {
     specPattern: 'cypress/e2e/**/*.{cy,spec}.{js,jsx,ts,tsx}',
-    baseUrl: 'http://localhost:4173'
+    baseUrl: 'http://localhost:5173'
   }
 })

--- a/vue-project/cypress/e2e/example.cy.js
+++ b/vue-project/cypress/e2e/example.cy.js
@@ -2,7 +2,7 @@
 
 describe('My First Test', () => {
   it('visits the app root url', () => {
-    cy.visit('/')
-    cy.contains('h1', 'You did it!')
+    cy.visit('http://localhost:5173/')
+    cy.contains('h1', 'What do you have to do today?')
   })
 })

--- a/vue-project/package.json
+++ b/vue-project/package.json
@@ -7,8 +7,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "test:unit": "vitest",
-    "test:e2e": "start-server-and-test preview http://localhost:4173 'cypress run --e2e'",
-    "test:e2e:dev": "start-server-and-test 'vite dev --port 4173' http://localhost:4173 'cypress open --e2e'",
+    "test:e2e": "start-server-and-test preview http://localhost:5173 'cypress run --e2e'",
+    "test:e2e:dev": "start-server-and-test 'vite dev --port 5173' http://localhost:5173 'cypress open --e2e'",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore",
     "format": "prettier --write src/"
   },


### PR DESCRIPTION
## Description
Change all port numbers to 5173 for accurate config/testing

#### To validate
- [ ] Pull down branch
- [ ] Run `npm install`
- [ ] Run `npm run test:e2e` or `npmruntest:e2e:dev` to start Cypress
- [ ] Verify `example.cy.js` test passes ✅